### PR TITLE
added if statement to CountXVisit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: NCRNbirds
 Type: Package
 Title: Data analysis and visualzation for NCRN bird monitoring.
-Version: 0.1.15
+Version: 0.1.16
 Date: 2018-2-20
-Author: John Paul Schmit, Aaaron Weed
+Author: John Paul Schmit, Aaron Weed
 Maintainer: John Paul Schmit <john_schmit@nps.gov>
 Description: This pacakge is designed to analyze and visualize data from the
     National Park Service, National Capital Region and North East Temperate Inventory and Monitoring

--- a/R/CountXVisit.R
+++ b/R/CountXVisit.R
@@ -68,7 +68,12 @@ setMethod(f="CountXVisit", signature=c(object="NCRNbirds"),
             ## Now we need to multiply the Visit1, Visit2 etc. columns from each matrix so that missing visits will get
             ## NA instead of 0 in the output
             
-            CountMat[4:ncol(CountMat)]<-CountMat[4:ncol(CountMat)]*VisitMat[4:ncol(CountMat)]
+          
+            if( ncol( CountMat)> 3) {
+              CountMat[4:ncol(CountMat)]<-CountMat[4:ncol(CountMat)]*VisitMat[4:ncol(CountMat)]
+            }
+           
+            
             CountMat<-CountMat %>% ungroup  # to fix errors with dplyr when maniplating grouped tables
             return(CountMat)
             


### PR DESCRIPTION
this addition now prevents the error trying to bind different size matrices together (CountMat and VisitMat) and either returns the correct df from CountXVisit or any empty df when there are no obs for that point-year combo