### PR TITLE
adds 'importCNNAPbirds.R' to Collate field in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,4 +63,5 @@ Collate:
     'summarizeTrend.R'
     'trendsPlot.R'
     'unmarkedBirds.R'
+    'importCNNAPbirds.R'
 RoxygenNote: 7.1.1


### PR DESCRIPTION
Hi there! 
Currently, the package fails to install (tested on Ubuntu 22.04 LTS, R version 4.2.1) with `devtools::install_github("NCRN/NCRNbirds")` due to a missing file in the Collate field of the DESCRIPTION file. This pull request fixes the installation of `NCRNbirds` by adding that missing file to the Collate field. 